### PR TITLE
Made werekitten unable to be cursed

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1949,7 +1949,7 @@ async def assign_roles(gamemode):
 
     for i in range(gamemode_roles['cursed villager'] if 'cursed villager' in gamemode_roles else 0):
         cursed_choices = [x for x in session[1] if get_role(x, 'role') not in\
-        ['wolf', 'werecrow', 'seer', 'fool', 'werekitten'] and 'cursed' not in session[1][x][3]]
+        ['wolf', 'werecrow', 'werekitten', 'seer', 'fool'] and 'cursed' not in session[1][x][3]]
         if cursed_choices:
             cursed = random.choice(cursed_choices)
             session[1][cursed][3].append('cursed')

--- a/bot.py
+++ b/bot.py
@@ -1949,7 +1949,7 @@ async def assign_roles(gamemode):
 
     for i in range(gamemode_roles['cursed villager'] if 'cursed villager' in gamemode_roles else 0):
         cursed_choices = [x for x in session[1] if get_role(x, 'role') not in\
-        ['wolf', 'werecrow', 'seer', 'fool'] and 'cursed' not in session[1][x][3]]
+        ['wolf', 'werecrow', 'seer', 'fool', 'werekitten'] and 'cursed' not in session[1][x][3]]
         if cursed_choices:
             cursed = random.choice(cursed_choices)
             session[1][cursed][3].append('cursed')


### PR DESCRIPTION
According to the ##werewolf wiki, werekittens are not supposed to be able to get the cursed villager template. Thus, I have removed the ability for that to happen in this port of the game.