### PR TITLE
Added bishop template, some changes to random game mode, and multiple bug fixes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4231,16 +4231,8 @@ async def game_loop(ses=None):
                 member = client.get_server(WEREWOLF_SERVER).get_member(player)
                 role = get_role(player, 'role')
                 if "silence_totem2" not in session[1][player][4]:
-                    if role in ['shaman', 'crazed shaman', 'wolf shaman'] and session[1][player][0]:
-                        if role == 'shaman':
-                            if session[6] == "mudkip":
-                                session[1][player][2] = random.choice(["pestilence_totem", "death_totem"]) if not night == 1 else "death_totem"
-                            elif session[6] == 'aleatoire':
-                                #protection (40%), death (20%), retribution (20%), silence (10%), desperation (5%), pestilence (5%).
-                                session[1][player][2] = random.choice(["protection_totem"] * 8 + ["death_totem"] * 4 + ["retribution_totem"] * 4 + ["silence_totem"] * 2 + ["desperation_totem"] + ["pestilence_totem"])
-                            else:
-                                session[1][player][2] = random.choice(SHAMAN_TOTEMS)
-                        elif role == 'wolf shaman':
+                    if role in ['crazed shaman', 'wolf shaman'] and session[1][player][0]:
+                        if role == 'wolf shaman':
                             if session[6] == "mudkip":
                                 session[1][player][4].append("totem:{}".format(random.choice(["protection_totem", "misdirection_totem"])))
                             else:
@@ -4253,9 +4245,21 @@ async def game_loop(ses=None):
                     elif role == 'piper':
                         session[1][player][4].append('charm')
                 else:
-                    if role in ['shaman', 'crazed shaman', 'piper'] and session[1][player][0]:
+                    if role in ['crazed shaman', 'piper'] and session[1][player][0]:
                         session[1][player][2] = player
-                if role == 'hunter' and session[1][player][0] and 'hunterbullet' not in session[1][player][4]:
+                if role == 'shaman' and session[1][player][0]:
+                    if session[6] == "mudkip":
+                        session[1][player][2] = random.choice(
+                            ["pestilence_totem", "death_totem"]) if not night == 1 else "death_totem"
+                    elif session[6] == 'aleatoire':
+                        # protection (40%), death (20%), retribution (20%), silence (10%), desperation (5%), pestilence (5%).
+                        session[1][player][2] = random.choice(
+                            ["protection_totem"] * 8 + ["death_totem"] * 4 + ["retribution_totem"] * 4 + [
+                                "silence_totem"] * 2 + ["desperation_totem"] + ["pestilence_totem"])
+                    else:
+                        session[1][player][2] = random.choice(SHAMAN_TOTEMS)
+                    log_msg.append("{} ({}) HAS {}".format(get_name(player), player, session[1][player][2]))
+                elif role == 'hunter' and session[1][player][0] and 'hunterbullet' not in session[1][player][4]:
                     session[1][player][2] = player
                 elif role == 'executioner' and session[1][player][0] and not [x for x in session[1][player][4] if x.startswith('execute:')]:
                     if [x for x in [y for y in session[1] if session[1][y][0]] if get_role(x, 'actualteam') == 'village']:
@@ -4296,7 +4300,7 @@ async def game_loop(ses=None):
                                     'seer', 'oracle', 'harlot', 'hunter', 'augur',
                                     'guardian angel', 'succubus', 'hag', 'warlock', 'bodyguard', 'turncoat', 'serial killer', 'hot potato'] and 'silence_totem2' not in session[1][player][4]:
                             end_night = end_night and (session[1][player][2] != '')
-                        if role in ['shaman', 'crazed shaman']:
+                        if role in ['shaman', 'crazed shaman'] and 'silence_totem2' not in session[1][player][4]:
                             end_night = end_night and (session[1][player][2] in session[1])
                         if role == "wolf shaman":
                             end_night = end_night and not [x for x in session[1][player][4] if x.startswith("totem:")]

--- a/bot.py
+++ b/bot.py
@@ -1952,13 +1952,13 @@ async def cmd_notify(message, parameters):
             await reply(message, "You are already in the notify list.")
             return
         notify_me.append(message.author.id)
-        await reply(message, "You will be notified by {}notify.".format(BOT_PREFIX))
+        await reply(message, "You will be notified by `{}notify`.".format(BOT_PREFIX))
     elif parameters in ['false', '-', 'no']:
         if not notify:
             await reply(message, "You are not in the notify list.")
             return
         notify_me.remove(message.author.id)
-        await reply(message, "You will not be notified by {}notify.".format(BOT_PREFIX))
+        await reply(message, "You will not be notified by `{}notify`.".format(BOT_PREFIX))
     else:
         await reply(message, commands['notify'][2].format(BOT_PREFIX))
 
@@ -5445,8 +5445,8 @@ async def game_start_timeout_loop():
     if not session[0] and len(session[1]) > 0:
         session[0] = True
         await client.change_presence(game=client.get_server(WEREWOLF_SERVER).me.game, status=discord.Status.online)
-        await send_lobby("{0}, the game has taken too long to start and has been cancelled. "
-                          "If you are still here and would like to start a new game, please do `!join` again.".format(PLAYERS_ROLE.mention))
+        await send_lobby("{}, the game has taken too long to start and has been cancelled. "
+                          "If you are still here and would like to start a new game, please do `{}join` again.".format(PLAYERS_ROLE.mention, BOT_PREFIX))
         perms = client.get_channel(GAME_CHANNEL).overwrites_for(client.get_server(WEREWOLF_SERVER).default_role)
         perms.send_messages = True
         await client.edit_channel_permissions(client.get_channel(GAME_CHANNEL), client.get_server(WEREWOLF_SERVER).default_role, perms)

--- a/bot.py
+++ b/bot.py
@@ -489,7 +489,7 @@ async def cmd_start(message, parameters):
     if session[0]:
         return
     if message.author.id not in session[1]:
-        await reply(message, random.choice(lang['notplayingstart']))
+        await reply(message, random.choice(lang['notplayingstart']).format(p=BOT_PREFIX))
         return
     if len(session[1]) < MIN_PLAYERS:
         await reply(message, random.choice(lang['minplayers']).format(MIN_PLAYERS))

--- a/bot.py
+++ b/bot.py
@@ -3468,14 +3468,16 @@ def end_game_stats():
             role_dict['cursed villager'].append(player)
         if 'gunner' in session[1][player][3]:
             role_dict['gunner'].append(player)
+        if 'sharpshooter' in session[1][player][3]:
+            role_dict['sharpshooter'].append(player)
         if 'assassin' in session[1][player][3]:
             role_dict['assassin'].append(player)
         if 'mayor' in session[1][player][3]:
             role_dict['mayor'].append(player)
-        if 'sharpshooter' in session[1][player][3]:
-            role_dict['sharpshooter'].append(player)
         if 'bishop' in session[1][player][3]:
             role_dict['bishop'].append(player)
+        if 'blessed' in session[1][player][3]:
+            role_dict['blessed villager'].append(player)
 
     for key in sort_roles(role_dict):
         value = sort_players(role_dict[key])


### PR DESCRIPTION
- Added bishop template
- Made some changes to the random game mode:
     - Slightly reduced the maximum ratio of wolves to total players
     - Slightly reduced the chances of being cursed and the chances of being gunner
     - There is now the possibility of being assigned assassin, mayor, and/or blessed villager at the beginning of the game
- Blessed villager now appears in end game stats
- Death by doomsayer's see is now set to be a kill by wolf team instead of village team
- Serial killer's retract does not appear in wolf chat anymore
- Bodyguard now protects against serial killer's kill
- Silenced shaman is now told the totem that it would be able to give if it was not silenced
- Vengeful ghost now receives a message if it is consecrated and tries to kill
- The death messages of the entranced when all succubi die are now in one sentence
- Edited turncoat's description to include that it can pass
- Fixed {p} appearing instead of prefix when trying to start the game without joining
- Fixed ! always appearing, regardless of prefix, when game start reaches timeout
- Fixed some message formatting regarding the hot potato, succubus, and bodyguard roles as well as the notify command