### PR TITLE
Some changes to executioner

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -977,14 +977,18 @@ async def cmd_stats(message, parameters):
                         role_dict[role][0] -= 1
                         role_dict[role][1] -= 1
         
-        #amnesiacs show amnesiac even after turning
-        for player in session[1]:
-            role = get_role(player, 'role')
-            if session[1][player][0] and "amnesiac" in session[1][player][4]:
-                role_dict["amnesiac"][0] += 1
-                role_dict["amnesiac"][1] += 1
+        # after turning, amnesiac/executioner is shown instead of current role
+        for player in [x for x in session[1] if session[1][x][0]]:
+            if "amnesiac" in session[1][player][4] or "executioner" in session[1][player][4]:
+                role = get_role(player, 'role')
                 role_dict[role][0] -= 1
                 role_dict[role][1] -= 1
+                if "amnesiac" in session[1][player][4]:
+                    role_dict["amnesiac"][0] += 1
+                    role_dict["amnesiac"][1] += 1
+                else:
+                    role_dict["executioner"][0] += 1
+                    role_dict["executioner"][1] += 1
 
         reply_msg += "\nCurrent roles: "
         for template in TEMPLATES_ORDERED:
@@ -3468,10 +3472,6 @@ def end_game_stats():
         if 'wolf_cub' in session[1][player][4]:
             session[1][player][1] = 'wolf cub'
             session[1][player][4].remove('wolf_cub')
-        if session[1][player][1] == 'jester' and 'executioner' in session[1][player][4]:
-            session[1][player][1] = 'executioner'
-            if 'lynched' in session[1][player][4]:
-                session[1][player][4].append('win')
         role_dict[session[1][player][1]].append(player)
         if 'cursed' in session[1][player][3]:
             role_dict['cursed villager'].append(player)


### PR DESCRIPTION
Executioner that turned into a jester now shows as executioner (instead of jester) in stats and shows as jester in end game stats (instead of executioner)
(These are the same changes as pull request #61, which was earlier merged, but the changes did not go through)